### PR TITLE
docs: update README and Anleitung for v5.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Pi-hole Maintenance PRO MAX (v5.0)
+# Pi-hole Maintenance PRO MAX (v5.1.2)
 
 This script provides a comprehensive maintenance routine for **Pi-hole v6.x** installations. It offers colorised output, detailed logging, and an interactive step-based workflow.
 
@@ -10,7 +10,7 @@ This script provides a comprehensive maintenance routine for **Pi-hole v6.x** in
 - Colored output with symbols and progress indicators
 - System package update and cleanup via `apt`
 - Pi-hole self-update and Gravity blocklist refresh
-- Backup of `adlist` and `domainlist` using `pihole-FTL sqlite3`
+- Multi-stage Pi-hole backup with compressed `/etc/pihole` snapshot, Gravity `adlist` dump, and FTL schema export
 - DNS reload and basic network diagnostics (ping, dig, port check)
 - Statistics for top domains and clients
 - Raspberry Pi health info (uptime, temperature, resource usage)
@@ -20,6 +20,11 @@ This script provides a comprehensive maintenance routine for **Pi-hole v6.x** in
 ---
 
 ## 📜 Changelog
+
+### v5.1.2
+- **New backup destination**: `/var/backups/pihole_backup_<timestamp>/` stores each run in its own directory
+- **Split backup flow**: separate steps for tarball, Gravity `adlist` dump, and FTL schema export with clearer progress output
+- **FTL schema dump** now included alongside the Gravity backup for easier inspection
 
 ### v5.0
 - **Step-by-step flow** with colored status output  
@@ -49,12 +54,17 @@ sudo ./pihole_maintenance_pro.sh
 
 📁 Backups
 
-If pihole-FTL sqlite3 is available, two backup files will be saved to:
+If pihole-FTL sqlite3 is available, backup artifacts will be saved to:
 
-/etc/pihole/backup_v6/adlist.sql
-/etc/pihole/backup_v6/domainlist.sql
+`/var/backups/pihole_backup_<timestamp>/`
 
-Backups will be skipped if write permissions are missing.
+This directory contains:
+
+- `pihole_backup.tar.gz` – compressed snapshot of `/etc/pihole`
+- `adlist.sql` – Gravity adlist dump via `pihole-FTL sqlite3`
+- `ftl_schema.sql` – FTL schema export via `pihole-FTL sqlite3`
+
+Backups will be skipped if write permissions are missing or if the backup directory cannot be created.
 
 
 ---

--- a/docs/Anleitung_DE.md
+++ b/docs/Anleitung_DE.md
@@ -1,4 +1,4 @@
-# 🇩🇪 Anleitung: Pi-hole Maintenance PRO MAX
+# 🇩🇪 Anleitung: Pi-hole Maintenance PRO MAX (v5.1.2)
 
 Dieses Skript dient der vollständigen Pflege und Wartung eines Pi-hole v6.x Systems auf einem Raspberry Pi. Es bietet farbige Ausgabe, detailliertes Logging und eine strukturierte Schritt-für-Schritt-Ausführung.
 
@@ -10,8 +10,20 @@ Dieses Skript dient der vollständigen Pflege und Wartung eines Pi-hole v6.x Sys
 - Healthchecks (Ping, dig, Port 53, FTL)
 - Statistiken zu Top-Domains und -Clients
 - Ressourcen- und Temperaturanzeige des Raspberry Pi
-- SQLite-Backup der `adlist` & `domainlist`
+- Mehrstufiges Backup (Tarball + Gravity-`adlist`-Dump + FTL-Schema-Export)
 - Logging aller Schritte in `/var/log/`
+
+## 📁 Backup
+
+Backups werden jetzt schrittweise erstellt und landen in einem eigenen Verzeichnis:
+
+`/var/backups/pihole_backup_<timestamp>/`
+
+Enthalten sind:
+
+- `pihole_backup.tar.gz` – komprimierter Snapshot von `/etc/pihole`
+- `adlist.sql` – Export der Gravity-Werbelisten über `pihole-FTL sqlite3`
+- `ftl_schema.sql` – Dump des FTL-Schemas für Referenz und Troubleshooting
 
 ## 🔧 Ausführung
 


### PR DESCRIPTION
## Summary
- refresh the README for v5.1.2 with the new backup destination, split backup flow, and FTL schema export details
- update the German guide to mirror the new version number, multi-stage backup description, and timestamped backup path

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68c9348ec64083339e609dbd83f2d0a9