### PR TITLE
Update backup docs for FTL schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This script provides a comprehensive maintenance routine for **Pi-hole v6.x** in
 - Colored output with symbols and progress indicators
 - System package update and cleanup via `apt`
 - Pi-hole self-update and Gravity blocklist refresh
-- Backup of `adlist` and `domainlist` using `pihole-FTL sqlite3`
+- Backup of `adlist` and FTL schema using `sqlite3`
 - DNS reload and basic network diagnostics (ping, dig, port check)
 - Statistics for top domains and clients
 - Raspberry Pi health info (uptime, temperature, resource usage)
@@ -24,7 +24,7 @@ This script provides a comprehensive maintenance routine for **Pi-hole v6.x** in
 ### v5.0
 - **Step-by-step flow** with colored status output  
 - **Full logging** to `/var/log/pihole_maintenance_pro_<timestamp>.log`  
-- **Native backups** via `pihole-FTL sqlite3` for `adlist` & `domainlist` (no external `sqlite3` dependency)  
+- **Native backups** for `adlist` & FTL schema using `sqlite3`
 - **Extra stats**: Top domains & top clients  
 - **Extra Raspberry Pi health info**: uptime, temperature, resource usage  
 - **Cron-ready**: OS/Pi-hole updates, gravity refresh, DNS reload, ping/dig/port checks  
@@ -49,10 +49,10 @@ sudo ./pihole_maintenance_pro.sh
 
 📁 Backups
 
-If pihole-FTL sqlite3 is available, two backup files will be saved to:
+If `sqlite3` is available, two backup files will be saved to:
 
 /etc/pihole/backup_v6/adlist.sql
-/etc/pihole/backup_v6/domainlist.sql
+/etc/pihole/backup_v6/ftl_schema.sql
 
 Backups will be skipped if write permissions are missing.
 

--- a/docs/Anleitung_DE.md
+++ b/docs/Anleitung_DE.md
@@ -10,7 +10,7 @@ Dieses Skript dient der vollständigen Pflege und Wartung eines Pi-hole v6.x Sys
 - Healthchecks (Ping, dig, Port 53, FTL)
 - Statistiken zu Top-Domains und -Clients
 - Ressourcen- und Temperaturanzeige des Raspberry Pi
-- SQLite-Backup der `adlist` & `domainlist`
+- SQLite-Backup der `adlist` & des FTL-Schemas
 - Logging aller Schritte in `/var/log/`
 
 ## 🔧 Ausführung


### PR DESCRIPTION
## Summary
- update README feature and changelog entries to mention the FTL schema backup
- refresh README backup section to call out sqlite3 usage and new schema file name
- adjust the German instructions to describe the adlist and FTL schema backup

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c9348f987083338592f7e21034f330

## Zusammenfassung von Sourcery

Dokumentation überarbeiten, um domainlist-Backups durch FTL-Schema-Backups zu ersetzen, Werkzeugerwähnungen, Dateinamen und Changelog-Einträge sowohl in der README als auch in der deutschen Anleitung zu aktualisieren.

Verbesserungen:
- FTL-Schema-Backup anstelle von domainlist in der Feature-Liste und den Changelog-Einträgen erwähnen

Dokumentation:
- Backup-Abschnitt der README aktualisieren, um generisches sqlite3 zu verwenden, auf ftl_schema.sql zu verweisen und Dateipfade zu aktualisieren
- Deutsche Anleitung anpassen, um adlist- und FTL-Schema-Backups zu beschreiben

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Revise documentation to replace domainlist backups with FTL schema backups, update tool mentions, file names, and changelog entries in both README and German instructions.

Enhancements:
- Mention FTL schema backup instead of domainlist in feature list and changelog entries

Documentation:
- Refresh README backup section to use generic sqlite3, point to ftl_schema.sql, and update file paths
- Adjust German Anleitung to describe adlist and FTL schema backup

</details>