### PR TITLE
docs: clarify sqlite3 backup details

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Pi-hole Maintenance PRO MAX (v5.0)
+# Pi-hole Maintenance PRO MAX (v5.1.2)
 
 This script provides a comprehensive maintenance routine for **Pi-hole v6.x** installations. It offers colorised output, detailed logging, and an interactive step-based workflow.
 
@@ -10,7 +10,7 @@ This script provides a comprehensive maintenance routine for **Pi-hole v6.x** in
 - Colored output with symbols and progress indicators
 - System package update and cleanup via `apt`
 - Pi-hole self-update and Gravity blocklist refresh
-- Backup of `adlist` and `domainlist` using `pihole-FTL sqlite3`
+- Multi-stage Pi-hole backup with compressed `/etc/pihole` snapshot, Gravity `adlist` dump, and FTL schema export
 - DNS reload and basic network diagnostics (ping, dig, port check)
 - Statistics for top domains and clients
 - Raspberry Pi health info (uptime, temperature, resource usage)
@@ -21,15 +21,20 @@ This script provides a comprehensive maintenance routine for **Pi-hole v6.x** in
 
 ## 📜 Changelog
 
+### v5.1.2
+- **New backup destination**: `/var/backups/pihole_backup_<timestamp>/` stores each run in its own directory
+- **Split backup flow**: separate steps for tarball, Gravity `adlist` dump, and FTL schema export with clearer progress output
+- **FTL schema dump** now included alongside the Gravity backup for easier inspection
+
 ### v5.0
-- **Step-by-step flow** with colored status output  
-- **Full logging** to `/var/log/pihole_maintenance_pro_<timestamp>.log`  
-- **Native backups** via `pihole-FTL sqlite3` for `adlist` & `domainlist` (no external `sqlite3` dependency)  
-- **Extra stats**: Top domains & top clients  
-- **Extra Raspberry Pi health info**: uptime, temperature, resource usage  
-- **Cron-ready**: OS/Pi-hole updates, gravity refresh, DNS reload, ping/dig/port checks  
-- **Backup location**: `/etc/pihole/backup_v6/` (if possible)  
-- **Upgrade**: Just replace the script with the latest from the repo – no setup needed  
+- **Step-by-step flow** with colored status output
+- **Full logging** to `/var/log/pihole_maintenance_pro_<timestamp>.log`
+- **Native backups** via Pi-hole's bundled SQLite interface for Gravity tables (v5.0 exported both `adlist` and `domainlist`)
+- **Extra stats**: Top domains & top clients
+- **Extra Raspberry Pi health info**: uptime, temperature, resource usage
+- **Cron-ready**: OS/Pi-hole updates, gravity refresh, DNS reload, ping/dig/port checks
+- **Backup location**: `/etc/pihole/backup_v6/` (legacy path, replaced by timestamped directories in v5.1.2)
+- **Upgrade**: Just replace the script with the latest from the repo – no setup needed
 - **Compatibility**: v5 is a drop-in replacement for v4 with improved UX/logging and integrated SQLite backup
 
 ---
@@ -49,12 +54,17 @@ sudo ./pihole_maintenance_pro.sh
 
 📁 Backups
 
-If pihole-FTL sqlite3 is available, two backup files will be saved to:
+If the `sqlite3` CLI is available (Pi-hole ships one via `pihole-FTL sqlite3`), backup artifacts will be saved to:
 
-/etc/pihole/backup_v6/adlist.sql
-/etc/pihole/backup_v6/domainlist.sql
+`/var/backups/pihole_backup_<timestamp>/`
 
-Backups will be skipped if write permissions are missing.
+This directory contains:
+
+- `pihole_backup.tar.gz` – compressed snapshot of `/etc/pihole`
+- `adlist.sql` – Gravity adlist dump captured with `sqlite3` (5-second lock timeout)
+- `ftl_schema.sql` – FTL schema export captured with `sqlite3` (5-second lock timeout)
+
+Backups will be skipped if write permissions are missing or if the backup directory cannot be created.
 
 
 ---

--- a/docs/Anleitung_DE.md
+++ b/docs/Anleitung_DE.md
@@ -1,4 +1,4 @@
-# 🇩🇪 Anleitung: Pi-hole Maintenance PRO MAX
+# 🇩🇪 Anleitung: Pi-hole Maintenance PRO MAX (v5.1.2)
 
 Dieses Skript dient der vollständigen Pflege und Wartung eines Pi-hole v6.x Systems auf einem Raspberry Pi. Es bietet farbige Ausgabe, detailliertes Logging und eine strukturierte Schritt-für-Schritt-Ausführung.
 
@@ -10,8 +10,20 @@ Dieses Skript dient der vollständigen Pflege und Wartung eines Pi-hole v6.x Sys
 - Healthchecks (Ping, dig, Port 53, FTL)
 - Statistiken zu Top-Domains und -Clients
 - Ressourcen- und Temperaturanzeige des Raspberry Pi
-- SQLite-Backup der `adlist` & `domainlist`
+- Mehrstufiges Backup (Tarball + Gravity-`adlist`-Dump + FTL-Schema-Export)
 - Logging aller Schritte in `/var/log/`
+
+## 📁 Backup
+
+Backups werden jetzt schrittweise erstellt und landen in einem eigenen Verzeichnis:
+
+`/var/backups/pihole_backup_<timestamp>/`
+
+Enthalten sind:
+
+- `pihole_backup.tar.gz` – komprimierter Snapshot von `/etc/pihole`
+- `adlist.sql` – Export der Gravity-Werbelisten über die `sqlite3`-CLI (5 s Lock-Timeout, Pi-hole liefert `pihole-FTL sqlite3` mit)
+- `ftl_schema.sql` – Dump des FTL-Schemas via `sqlite3` (ebenfalls 5 s Lock-Timeout) für Referenz und Troubleshooting
 
 ## 🔧 Ausführung
 


### PR DESCRIPTION
## Summary
- update the README changelog to flag the legacy backup path and describe the SQLite interface the script now uses
- clarify the README backup section to note the sqlite3 CLI and lock timeout for the adlist and schema exports
- sync the German guide with the sqlite3-based backup workflow and timing details

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68c9348ec64083339e609dbd83f2d0a9