### PR TITLE
fix(maintenance): guard step 00 RFC1918 extraction

### DIFF
--- a/pihole_maintenance_pro.sh
+++ b/pihole_maintenance_pro.sh
@@ -269,7 +269,21 @@ collect_system_info() {
 extract_step_data() {
   local step_num="$1" output="$2"
   case "$step_num" in
-    00) STEP_DATA[00_ip]=$(echo "$output" | grep -oE '192\.168\.[0-9]+\.[0-9]+|10\.[0-9]+\.[0-9]+\.[0-9]+|172\.(1[6-9]|2[0-9]|3[0-1])\.[0-9]+\.[0-9]+' | head -1) ;;
+    # Fehlende RFC1918-IP (grep Exit 1) ist ein erlaubter Zustand und darf unter
+    # set -euo pipefail nicht abbrechen; echte grep-Fehler werden weitergereicht.
+    00)
+      local step_ip=""
+      if step_ip=$(grep -m1 -oE '192\.168\.[0-9]+\.[0-9]+|10\.[0-9]+\.[0-9]+\.[0-9]+|172\.(1[6-9]|2[0-9]|3[0-1])\.[0-9]+\.[0-9]+' <<< "$output"); then
+        STEP_DATA[00_ip]="$step_ip"
+      else
+        local grep_rc=$?
+        if [[ "$grep_rc" -eq 1 ]]; then
+          STEP_DATA[00_ip]=""
+        else
+          return "$grep_rc"
+        fi
+      fi
+      ;;
     03) STEP_DATA[03_version]=$(echo "$output" | grep "Core version" | awk '{print $4}') ;;
     07) STEP_DATA[07_listeners]=$(echo "$output" | wc -l) ;;
     08) STEP_DATA[08_response]=$(echo "$output" | grep -oE '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+' | head -1) ;;


### PR DESCRIPTION
## Was & Warum

`extract_step_data` konnte unter `set -euo pipefail` einen sonst erfolgreichen Lauf abbrechen, wenn die **Step-00-Ausgabe keine RFC1918-IP** enthielt.

**Ursache:** Im Case `00)` lieferte `grep` bei fehlendem Treffer Exit-Code `1`. Zusammen mit `pipefail` schlug damit die einfache Zuweisung `STEP_DATA[00_ip]=$(… grep … | head -1)` fehl, und `errexit` beendete den gesamten Lauf – obwohl Step 00 erfolgreich war. Die Funktion wird in `run_step` als letztes Kommando nach dem finalen `&&` aufgerufen, weshalb `set -e` innerhalb der Funktion aktiv ist.

## Korrektur

- Case `00)` nutzt jetzt `grep -m1 -oE` (statt `grep … | head -1`) mit **gezielter Exit-Code-Behandlung**:
  - Exit `1` (kein RFC1918-Treffer) → `STEP_DATA[00_ip]=""` (erlaubter Zustand, kein Abbruch).
  - Jeder andere Exit-Code (z. B. `2` = echter grep-Fehler) → via `return "$grep_rc"` weitergereicht.
- **Kein pauschales `|| true`** über die Pipeline – echte Fehler bleiben Fehler.
- Betrifft ausschließlich Step 00. Steps 03/08/09/10 bleiben unverändert.
- Dashboard-/Summary-/JSON-/Flag-Verhalten unverändert: eine leere IP war schon immer ein zulässiger Zustand (`${STEP_DATA[00_ip]:+…}`).

## Verifikation

- `git diff --check` → rc 0
- `bash -n pihole_maintenance_pro.sh` → rc 0
- `make check` → rc 0 (`shellcheck`/`shfmt` lokal nicht installiert → in CI geprüft)
- Regressionstest (lokaler Harness, siehe unten):
  - Fall A: `192.168.1.50`, `10.0.5.7`, `172.16.3.9` → Exit 0, IP korrekt erfasst.
  - Fall B: nur `8.8.8.8` → Exit 0, IP leer, **kein Abbruch** unter `set -euo pipefail`.

## Hinweis zum Test

Ein reproduzierbarer, nicht-destruktiver Regression-Harness liegt unter `scripts/test-repo.sh` – dieser Pfad ist in `.gitignore` bewusst als „Local test scripts, not for commit" ausgeschlossen, daher **nicht Teil dieses PR** (Repo-Konvention respektiert). Er extrahiert die echte `extract_step_data`-Funktion aus dem Hauptskript und prüft Fall A/B isoliert; er wird zudem vom bestehenden `RUN_SELFTEST`-Hook erwartet.

## Nicht enthalten

Kein Auto-Merge, kein Tag, kein Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FqwkYKyZ1UPZB8uvezJAdJ)_