### PR TITLE
docs: modernize README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,67 +1,114 @@
 # 🛰️ Pi-hole Maintenance PRO MAX
 
-**Automated Pi-hole v6 Maintenance Script**
+**One idempotent, logged, cron-friendly maintenance run for Pi-hole v6 — safe to test before you trust it.**
 
 [![Build](https://img.shields.io/github/actions/workflow/status/TimInTech/pihole-maintenance-pro/ci-sanity.yml?branch=main)](https://github.com/TimInTech/pihole-maintenance-pro/actions)
 [![License](https://img.shields.io/github/license/TimInTech/pihole-maintenance-pro)](LICENSE)
 [![Buy Me a Coffee](https://img.shields.io/badge/Buy%20me%20a%20coffee-Donate-ffdd00?logo=buymeacoffee&logoColor=000&labelColor=fff)](https://buymeacoffee.com/timintech)
 
-<img src="https://skillicons.dev/icons?i=bash,linux" alt="Tech" />
-
 **Languages:** 🇬🇧 English (this file) • [🇩🇪 Deutsch](README.de.md)
 
 ---
 
-## What & Why
+## What & why
 
-Automated Pi-hole v6 maintenance script for Raspberry Pi OS (Bookworm/Trixie) with logging and health checks.
+`pihole-maintenance-pro` is a single Bash script that runs the recurring maintenance a Pi-hole v6
+host needs — OS package updates, `pihole -up`, gravity/blocklist refresh, plus DNS and system
+health checks — as **one repeatable, timestamped, log-producing run** instead of a pile of
+hand-typed commands and half-remembered cron lines.
 
-## Features
+The problem it solves: manual Pi-hole upkeep is easy to forget, easy to get wrong under cron's
+reduced `PATH`, and hard to audit after the fact. This script makes the run **idempotent**, logs
+everything to `/var/log`, takes a backup **before** it touches Pi-hole, and lets you **dry-test it
+without root and without changing anything** first.
 
-- APT update/upgrade/autoremove/autoclean
-- Pi-hole update (`-up`), gravity (`-g`), optional FTL restart (`--restart-ftl`)
-- Health checks: port 53, `dig`, GitHub reachability
-- Optional Tailscale info, FTL toplists via `sqlite3`
-- Performance dashboard & intelligent end-of-run summary
-- Automatic local backup prior to Pi-hole changes
-- Installer drops a weekly cron (`0 4 * * 0`) out of the box (idempotent)
-- Logs in `/var/log/pihole_maintenance_pro_<timestamp>.log`
+### Who it's for
 
-## Quickstart
+- Pi-hole **v6** users on **Raspberry Pi OS (Bookworm / Trixie)** (also works on comparable
+  Debian-based hosts).
+- Anyone running Pi-hole maintenance **unattended via cron** who wants logs, health checks, and a
+  safe way to verify the run before scheduling it.
 
-**Installer:**
+## Why this over a plain maintenance one-liner
+
+| Concern | A plain `apt update && pihole -up && pihole -g` | This project |
+| --- | --- | --- |
+| Test before trusting | none | non-destructive selftest, no root, no changes |
+| Backups | none | auto backup **before** update/gravity |
+| Health checks | none | port 53, `dig`, DNS local/external, FTL analytics |
+| Skip specific steps | edit the command | granular `--no-*` flags |
+| Output | raw stdout | timestamped log + summary + optional JSON |
+| Cron reliability | breaks on reduced `PATH` | sets a full `PATH` early |
+| Interrupt handling | partial state | clean, once-only cleanup on Ctrl-C |
+
+## Quick Start
+
+**1. Try it safely first — no root, no system changes:**
+
+```bash
+git clone https://github.com/TimInTech/pihole-maintenance-pro.git
+cd pihole-maintenance-pro
+RUN_SELFTEST=1 bash pihole_maintenance_pro.sh --no-apt --no-upgrade --no-gravity --no-dnsreload
+```
+
+**2. Install (script + healthcheck + weekly cron):**
 
 ```bash
 bash -c "$(curl -fsSL https://raw.githubusercontent.com/TimInTech/pihole-maintenance-pro/main/scripts/install.sh)"
 ```
 
-<!-- UNINSTALL:BEGIN -->
-## Update / Overwrite (safe re-install)
-
-Use this to pull and overwrite with the latest release:
+**3. Run a real maintenance pass on your Pi-hole host:**
 
 ```bash
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/TimInTech/pihole-maintenance-pro/main/scripts/install.sh)"
+sudo /usr/local/bin/pihole_maintenance_pro.sh
 ```
 
-## Uninstall (clean removal)
+## Safety principles
+
+- **Non-destructive selftest.** `RUN_SELFTEST=1` skips the root check and, combined with the
+  `--no-*` flags, performs no APT, upgrade, or gravity changes — ideal for CI and a first look.
+- **Backup before change.** A snapshot of `/etc/pihole` (`*.db`, `pihole.toml`, host lists) is
+  written to `/etc/pihole/backup_<timestamp>` **before** `pihole -up` and before `pihole -g`.
+  Add `--backup` for an extra rotated snapshot under `/var/backups/pihole/<timestamp>` (keeps the
+  last 5).
+- **Opt out per step.** `--no-apt`, `--no-upgrade`, `--no-gravity` let you scope exactly what runs.
+- **Predictable exit codes** (see table below) make it safe to gate in scripts and cron.
+- **Clean interrupts.** `SIGINT`/`SIGTERM` (Ctrl-C) render the summary and clean up the temp
+  directory exactly once.
+- **Reversible install.** A one-command [uninstall](#update--uninstall) removes the script, logs,
+  temp data, and cron entry.
+
+## Features
+
+- APT `update` / `upgrade` / `autoremove` / `autoclean`
+- Pi-hole update (`pihole -up`), gravity refresh (`pihole -g`), optional FTL restart
+  (`--restart-ftl`, only when needed on v6)
+- Health checks: port 53 listeners, `dig`, local & external DNS resolution, GitHub reachability
+- Optional Tailscale info and FTL toplists via `sqlite3`
+- Performance dashboard and an end-of-run summary
+- Automatic pre-change Pi-hole backup; optional rotated backup via `--backup`
+- Machine-readable output via `--json`
+- Installer provisions a weekly cron (`0 4 * * 0`) idempotently
+- Timestamped logs in `/var/log/pihole_maintenance_pro_<timestamp>.log`
+
+## Requirements
+
+- Pi-hole **v6** with the `pihole` CLI on `PATH`
+- Raspberry Pi OS (Bookworm / Trixie) or a comparable Debian-based system
+- Bash 5+, `sudo`/root for real runs
+- Optional: `sqlite3` (FTL toplists), a configured `PIHOLE_API_URL` for the healthcheck tool
+
+> Compatibility note: this is designed for current Pi-hole v6 maintenance workflows. Verify on your
+> own host with the non-destructive selftest before scheduling it in cron.
+
+## Installation
+
+**Installer (recommended)** — installs the maintenance script and
+`tools/pihole_api_healthcheck.sh` to `/usr/local/bin` and adds a weekly cron:
 
 ```bash
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/TimInTech/pihole-maintenance-pro/main/scripts/uninstall.sh)"
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/TimInTech/pihole-maintenance-pro/main/scripts/install.sh)"
 ```
-
-> These commands are idempotent: *Update* always replaces the installed script; *Uninstall* removes the script, logs, temp data, and the cron entry.
-<!-- UNINSTALL:END -->
-
-### Flags
-
-- `--no-apt` – skips APT steps (update/upgrade/autoremove/autoclean)
-- `--no-upgrade` – does **not** run `pihole -up`
-- `--no-gravity` – skips `pihole -g` (blocklists/Gravity update)
-- `--no-dnsreload` – deprecated in v6 (no-op)
-- `--restart-ftl` – restart pihole-FTL at the end (v6: only if needed)
-- `--backup` – creates a backup before Pi-hole ops under `/var/backups/pihole/`
-- `--json` – outputs machine-readable JSON instead of the colored TUI
 
 **Manual installation:**
 
@@ -72,23 +119,75 @@ chmod +x pihole_maintenance_pro.sh
 sudo install -m 0755 pihole_maintenance_pro.sh /usr/local/bin/pihole_maintenance_pro.sh
 ```
 
-**Interactive usage:**
+<!-- UNINSTALL:BEGIN -->
+### Update / Uninstall
+
+Re-run the installer to pull and overwrite with the latest version (idempotent):
 
 ```bash
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/TimInTech/pihole-maintenance-pro/main/scripts/install.sh)"
+```
+
+Clean removal of the script, logs, temp data, and the cron entry:
+
+```bash
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/TimInTech/pihole-maintenance-pro/main/scripts/uninstall.sh)"
+```
+<!-- UNINSTALL:END -->
+
+## Non-destructive test / selftest
+
+Run this from a clone to validate behavior without root and without changing your system. It skips
+the root check (`RUN_SELFTEST=1`) and disables every mutating step (`--no-*`):
+
+```bash
+RUN_SELFTEST=1 bash pihole_maintenance_pro.sh --no-apt --no-upgrade --no-gravity --no-dnsreload
+```
+
+This is the same self-test the CI workflow uses. On a host without the `pihole` CLI the run exits
+cleanly instead of failing.
+
+## Typical usage
+
+```bash
+# Full interactive run
 sudo /usr/local/bin/pihole_maintenance_pro.sh
+
+# OS-only maintenance, leave Pi-hole untouched
+sudo /usr/local/bin/pihole_maintenance_pro.sh --no-upgrade --no-gravity
+
+# Pi-hole-only maintenance, skip APT
+sudo /usr/local/bin/pihole_maintenance_pro.sh --no-apt
+
+# Machine-readable output
+sudo /usr/local/bin/pihole_maintenance_pro.sh --json
 ```
 
-**With flags:**
+### Flags
 
-```bash
-sudo /usr/local/bin/pihole_maintenance_pro.sh --no-apt --no-upgrade --no-gravity --no-dnsreload
-```
+| Flag | Effect |
+| --- | --- |
+| `--no-apt` | Skip APT `update`/`upgrade`/`autoremove`/`autoclean` |
+| `--no-upgrade` | Skip `pihole -up` |
+| `--no-gravity` | Skip `pihole -g` (blocklists / gravity) |
+| `--no-dnsreload` | Deprecated on v6 (no-op; kept for compatibility) |
+| `--restart-ftl` | Restart `pihole-FTL` at the end (v6: only if needed) |
+| `--backup` | Extra rotated backup under `/var/backups/pihole/` before Pi-hole ops |
+| `--json` | Emit machine-readable JSON instead of the colored summary |
+| `-h`, `--help` | Show usage |
 
-## Real Pi-hole v6 sample run
+## Output, logs & JSON
 
-Captured on a Raspberry Pi with Pi-hole Core 6.1.4, Web 6.2.1, FTL 6.2.3 — this is the live dashboard + summary rendered by the current release:
+Every run writes a timestamped log to `/var/log/pihole_maintenance_pro_<timestamp>.log`.
+Per-step live lines use a unified, timestamped format (`[HH:MM:SS] OK|WARN|ERR …`). Use `--json`
+for a machine-readable result you can pipe into monitoring.
 
-```bash
+### Sample run (real Pi-hole v6)
+
+Captured on a Raspberry Pi with Pi-hole Core 6.1.4, Web 6.2.1, FTL 6.2.3 — the live dashboard and
+summary rendered by the current release:
+
+```text
 ╔═══════════════ PERFORMANCE DASHBOARD ═══════════════╗
 ║ 🚀 Load: 1.81     💾 RAM: 23%    🌡  Temp: 50°C    🗄  Disk: 9% ║
 ╚═══════════════════════════════════════════════════════╝
@@ -103,18 +202,21 @@ Captured on a Raspberry Pi with Pi-hole Core 6.1.4, Web 6.2.1, FTL 6.2.3 — thi
   #13  👥 FTL Client 25 active clients                  ✔ OK
 ```
 
-> **Output note (v5.3.2 refresh):** per-step live lines now use a unified, timestamped
-> format (`[HH:MM:SS] OK|WARN|ERR …`) instead of `✔ Erfolg`/`⚠ Warnung`. The end-of-run
-> dashboard and summary shown above are unchanged. `SIGINT`/`SIGTERM` (Ctrl-C) now render the
-> summary and clean up the temp dir exactly once. All flags, JSON output and steps are identical.
+## Exit codes
 
-The same production run confirms:
+| Code | Meaning |
+| --- | --- |
+| `0` | Success (also `--help`, and CI without the `pihole` CLI) |
+| `1` | Not run as root without `RUN_SELFTEST`, or a critical step failed |
+| `2` | Unknown option |
+| `127` | `pihole` CLI not found (outside CI) |
+| `130` | Interrupted (SIGINT / Ctrl-C) |
+| `143` | Terminated (SIGTERM) |
 
-- Backups are created before Pi-hole maintenance kicks in (e.g. `/etc/pihole/backup_20251025_100315`, `/etc/pihole/backup_20251025_100337`)
-- The installer provisions the recommended cron automatically: `0 4 * * 0 /usr/local/bin/pihole_maintenance_pro.sh >>/var/log/pihole_maint_cron.log 2>&1`
-- Security (Steps 20–26) and health checks (Steps 07–10) run green end-to-end
+## Scheduling (cron)
 
-**Recommended cron jobs:**
+The installer adds a weekly cron (`0 4 * * 0`) automatically. To schedule manually, set a full
+`PATH` — Trixie's cron runs with a reduced one:
 
 ```cron
 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
@@ -122,41 +224,55 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 30 3 * * * /usr/local/bin/pihole_maintenance_pro.sh >> /var/log/pihole_maintenance_pro.log 2>&1
 ```
 
-> Trixie/cron runs with a reduced PATH. Using a full PATH ensures both scripts run reliably. The installer now sets the weekly cron idempotently.
-
 ## Pi-hole v6 API notes
 
-- `setupVars.conf` is gone
-- Config lives in `/etc/pihole/pihole.toml`
-- API is served at `/api` instead of `/api.php`
-- Authentication uses session tokens: `POST /api/auth` returns `sid`, pass via header `X-FTL-SID`
-- The healthcheck script (`tools/pihole_api_healthcheck.sh`) can hit endpoints when `PIHOLE_API_URL` is set; set `PIHOLE_PASSWORD` to enable session login
-- Unbound is optional
+- `setupVars.conf` is gone; configuration lives in `/etc/pihole/pihole.toml`
+- The API is served at `/api` (not `/api.php`)
+- Authentication uses session tokens: `POST /api/auth` returns `sid`, passed via the `X-FTL-SID`
+  header
+- The healthcheck tool (`tools/pihole_api_healthcheck.sh`) can query endpoints when
+  `PIHOLE_API_URL` is set; set `PIHOLE_PASSWORD` to enable session login (see `.env.example`)
+- Unbound is optional and not required by this script
 
 ## Troubleshooting
 
-- `sqlite3` toplists:
+**Missing `sqlite3` (FTL toplists):**
 
-  ```bash
-  sudo apt update && sudo apt install -y sqlite3
-  ```
+```bash
+sudo apt update && sudo apt install -y sqlite3
+```
 
-* Locale warnings:
+**Test FTL database read access:**
 
-  ```bash
-  echo -e "en_GB.UTF-8 UTF-8\nde_DE.UTF-8 UTF-8" | sudo tee /etc/locale.gen >/dev/null
-  sudo locale-gen && sudo update-locale LANG=de_DE.UTF-8 LC_ALL=de_DE.UTF-8
-  ```
+```bash
+sudo sqlite3 -readonly /etc/pihole/pihole-FTL.db "SELECT COUNT(*) FROM queries;"
+```
 
-* Pi 3B note about `linux-image-rpi-v8`: ignorable on ARMv7.
+**Locale warnings:**
+
+```bash
+echo -e "en_GB.UTF-8 UTF-8\nde_DE.UTF-8 UTF-8" | sudo tee /etc/locale.gen >/dev/null
+sudo locale-gen && sudo update-locale LANG=de_DE.UTF-8 LC_ALL=de_DE.UTF-8
+```
+
+- **Cron didn't run reliably:** ensure a full `PATH` in the crontab (see [Scheduling](#scheduling-cron)).
+- **Pi 3B `linux-image-rpi-v8` note:** ignorable on ARMv7.
+
+## Contributing
+
+Contributions are welcome. See [`AGENTS.md`](AGENTS.md) for structure and conventions, and run the
+local checks before opening a PR:
+
+```bash
+make check   # bash -n + shellcheck + shfmt
+```
+
+Please follow Conventional Commits (`feat:`, `fix(scope):`, `docs:`, `ci:`, `chore:`).
 
 ## License
 
 MIT. See [LICENSE](LICENSE).
 
-*Last updated: 2025-10-25 • Version: 5.3.2*
-
 ## Support
 
-If this project helps you, you can support it here:
-[buymeacoffee.com/timintech](https://buymeacoffee.com/timintech)
+If this project helps you, you can support it here: [buymeacoffee.com/timintech](https://buymeacoffee.com/timintech)

--- a/README.md
+++ b/README.md
@@ -144,8 +144,10 @@ the root check (`RUN_SELFTEST=1`) and disables every mutating step (`--no-*`):
 RUN_SELFTEST=1 bash pihole_maintenance_pro.sh --no-apt --no-upgrade --no-gravity --no-dnsreload
 ```
 
-This is the same self-test the CI workflow uses. On a host without the `pihole` CLI the run exits
-cleanly instead of failing.
+This is the same self-test CI runs. It still requires the `pihole` CLI to get past the environment
+check: on a host **without** Pi-hole the script stops early with exit code `127` and makes no
+changes (CI sets `CI=1`, which turns that case into a clean exit `0`). For a pure syntax check on
+any machine, use `bash -n pihole_maintenance_pro.sh`.
 
 ## Typical usage
 
@@ -173,14 +175,16 @@ sudo /usr/local/bin/pihole_maintenance_pro.sh --json
 | `--no-dnsreload` | Deprecated on v6 (no-op; kept for compatibility) |
 | `--restart-ftl` | Restart `pihole-FTL` at the end (v6: only if needed) |
 | `--backup` | Extra rotated backup under `/var/backups/pihole/` before Pi-hole ops |
-| `--json` | Emit machine-readable JSON instead of the colored summary |
+| `--json` | Emit a machine-readable JSON block in place of the human-readable end-of-run summary |
 | `-h`, `--help` | Show usage |
 
 ## Output, logs & JSON
 
 Every run writes a timestamped log to `/var/log/pihole_maintenance_pro_<timestamp>.log`.
-Per-step live lines use a unified, timestamped format (`[HH:MM:SS] OK|WARN|ERR …`). Use `--json`
-for a machine-readable result you can pipe into monitoring.
+Per-step live lines use a unified, timestamped format (`[HH:MM:SS] OK|WARN|ERR …`). `--json`
+replaces the end-of-run summary with a machine-readable JSON block. Note that the progress/step
+lines are still printed to stdout **before** it, so capture or extract the trailing JSON rather
+than piping the whole run straight into `jq`.
 
 ### Sample run (real Pi-hole v6)
 


### PR DESCRIPTION
## Goal

Redesign `README.md` so a first-time GitHub visitor can, within the first screen, understand **what** `pihole-maintenance-pro` is, **which problem** it solves, **who** it's for, **why** it beats a hand-typed maintenance one-liner, and **how to test it safely** before trusting it. This is a **documentation-only** change aimed at building trust and improving star conversion.

## Key structural changes

- **Hero + honest claim** and a concise **What & why** (2–4 sentences) plus a **Who it's for** section, all above the fold.
- New **"Why this over a plain maintenance one-liner"** comparison table (test-before-trust, backups, health checks, cron reliability, interrupt handling).
- **Quick Start reordered to safety-first**: non-destructive selftest → installer → real run.
- Dedicated **Safety principles** section (selftest, pre-change backup + optional rotated `--backup`, per-step opt-outs, exit codes, once-only interrupt cleanup, reversible install).
- **Flags** and **Exit codes** promoted to reference tables; new **Output/logs/JSON** section (real sample dashboard kept verbatim).
- Trimmed/re-flowed Installation, Update/Uninstall, Scheduling, Pi-hole v6 API, Troubleshooting, and added a short **Contributing** section pointing to `AGENTS.md` + `make check`.
- Removed the decorative external `skillicons.dev` image; kept only the three real badges (Build/License/Buy-Me-a-Coffee).

## Deliberately NOT changed

- **No script logic changes** — `pihole_maintenance_pro.sh` and all other scripts are untouched.
- **No CI, tooling, tag, release, or issue changes.**
- **`README.de.md` left as-is** (English-only scope for this PR — see open risks).

## Accuracy

All described features, flags, exit codes, paths, and commands were cross-checked against the current code (`pihole_maintenance_pro.sh` v5.3.2, `scripts/install.sh`, CI `ci-sanity.yml`, `AGENTS.md`). Backup behavior is now described precisely: an automatic snapshot to `/etc/pihole/backup_<ts>` runs before update and gravity, and `--backup` adds a rotated snapshot under `/var/backups/pihole/` (keeps 5).

## Verification (exit codes)

- `git diff --check` → **exit 0** (no whitespace/conflict-marker issues).
- Internal links checked manually — `README.de.md`, `LICENSE`, `AGENTS.md`, `tools/…`, `scripts/…`, `.env.example` all resolve to real files.
- Every command/flag in the README verified to exist in the repo.
- `shellcheck` / `shfmt` are **not installed in this environment**, so `make check` was not run locally; the change is docs-only and touches no shell scripts, so CI (`ci-sanity.yml`) covers it.

## Open risks

- **`README.de.md` now lags** the English redesign; it should be updated in a follow-up for parity.
- The script's `--help` output omits `--backup` and `--restart-ftl`, though both flags are implemented and work; the README documents them. Minor upstream inconsistency, intentionally left untouched here (docs-only PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HPkbDi3s63kuhdfuNhgS8v

---
_Generated by [Claude Code](https://claude.ai/code/session_01HPkbDi3s63kuhdfuNhgS8v)_